### PR TITLE
Hash customisation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ logging = ["log"]
 [dependencies]
 cfg-if = "1.0"
 rand = "0.8"
+sysinfo = "0.20.3"
 log = { version = "0.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -48,9 +48,9 @@ fn main() {
 /// Increments a value that lives in shared memory
 fn increment_value(shmem_flink: &str, thread_num: usize) {
     // Create or open the shared memory mapping
-    let shmem = match ShmemConf::new().size(4096).flink(shmem_flink).create() {
+    let shmem = match ShmemConf::new(true).size(4096).flink(shmem_flink).create() {
         Ok(m) => m,
-        Err(ShmemError::LinkExists) => ShmemConf::new().flink(shmem_flink).open().unwrap(),
+        Err(ShmemError::LinkExists) => ShmemConf::new(true).flink(shmem_flink).open().unwrap(),
         Err(e) => {
             info!(
                 "Unable to create or open shmem flink {} : {}",

--- a/examples/event.rs
+++ b/examples/event.rs
@@ -6,9 +6,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     // Attempt to create a mapping or open if it already exists
     info!("Getting the shared memory mapping");
-    let shmem = match ShmemConf::new().size(4096).flink("event_mapping").create() {
+    let shmem = match ShmemConf::new(true).size(4096).flink("event_mapping").create() {
         Ok(m) => m,
-        Err(ShmemError::LinkExists) => ShmemConf::new().flink("event_mapping").open()?,
+        Err(ShmemError::LinkExists) => ShmemConf::new(true).flink("event_mapping").open()?,
         Err(e) => return Err(Box::new(e)),
     };
 

--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -46,9 +46,9 @@ fn main() {
 
 fn increment_value(shmem_flink: &str, thread_num: usize) {
     // Create or open the shared memory mapping
-    let shmem = match ShmemConf::new().size(4096).flink(shmem_flink).create() {
+    let shmem = match ShmemConf::new(true).size(4096).flink(shmem_flink).create() {
         Ok(m) => m,
-        Err(ShmemError::LinkExists) => ShmemConf::new().flink(shmem_flink).open().unwrap(),
+        Err(ShmemError::LinkExists) => ShmemConf::new(true).flink(shmem_flink).open().unwrap(),
         Err(e) => {
             info!(
                 "Unable to create or open shmem flink {} : {}",

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,10 @@ pub enum ShmemError {
     MappingIdExists,
     MapCreateFailed(u32),
     MapOpenFailed(u32),
+    UnmapFailed(nix::Error),
     UnknownOsError(u32),
+    DevShmOutOfMemory,
+    CannotReadDevShm
 }
 
 impl std::fmt::Display for ShmemError {
@@ -30,7 +33,10 @@ impl std::fmt::Display for ShmemError {
             ShmemError::MappingIdExists => f.write_str("Shared memory OS specific ID already exists"),
             ShmemError::MapCreateFailed(err) => write!(f, "Creating the shared memory failed, os error {}", err),
             ShmemError::MapOpenFailed(err) => write!(f, "Opening the shared memory failed, os error {}", err),
+            ShmemError::UnmapFailed(err) => write!(f, "Unmapping the shared memory failed, os (nix) error {}", err),
             ShmemError::UnknownOsError(err) => write!(f, "An unexpected OS error occurred, os error {}", err),
+            ShmemError::CannotReadDevShm => write!(f, "Cannot get stats for `/dev/shm`"),
+            ShmemError::DevShmOutOfMemory => write!(f, "`/dev/shm`is out of memory")
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,7 @@ pub enum ShmemError {
     UnmapFailed(nix::Error),
     UnknownOsError(u32),
     DevShmOutOfMemory,
-    CannotReadDevShm
+    CannotReadDevShm,
 }
 
 impl std::fmt::Display for ShmemError {
@@ -33,10 +33,10 @@ impl std::fmt::Display for ShmemError {
             ShmemError::MappingIdExists => f.write_str("Shared memory OS specific ID already exists"),
             ShmemError::MapCreateFailed(err) => write!(f, "Creating the shared memory failed, os error {}", err),
             ShmemError::MapOpenFailed(err) => write!(f, "Opening the shared memory failed, os error {}", err),
-            ShmemError::UnmapFailed(err) => write!(f, "Unmapping the shared memory failed, os (nix) error {}", err),
+            ShmemError::UnmapFailed(err) => write!(f, "Unmapping the shared memory failed, os (nix) error {}", err.to_string()),
             ShmemError::UnknownOsError(err) => write!(f, "An unexpected OS error occurred, os error {}", err),
+            ShmemError::DevShmOutOfMemory => write!(f, "`/dev/shm`is out of memory"),
             ShmemError::CannotReadDevShm => write!(f, "Cannot get stats for `/dev/shm`"),
-            ShmemError::DevShmOutOfMemory => write!(f, "`/dev/shm`is out of memory")
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,11 +266,11 @@ impl Shmem {
     }
     /// Returns a raw pointer to the mapping
     pub fn as_ptr(&self) -> *mut u8 {
-        self.mapping.map_ptr
+        self.mapping.map_ptr as *mut u8
     }
 
-    pub fn usize_prt(&self) -> usize {
-        self.mapping.map_ptr as usize
+    pub fn usize_ptr(&self) -> usize {
+        self.mapping.map_ptr
     }
     
     /// Returns mapping as a byte slice

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,9 @@ impl ShmemConf {
                     };
                 }
             }
-            Some(ref specific_id) => os_impl::create_mapping(specific_id, self.size, self.droppable)?,
+            Some(ref specific_id) => {
+                os_impl::create_mapping(specific_id, self.size, self.droppable)?
+            }
         };
         debug!("Created shared memory mapping '{}'", mapping.unique_id);
 
@@ -272,7 +274,7 @@ impl Shmem {
     pub fn usize_ptr(&self) -> usize {
         self.mapping.map_ptr
     }
-    
+
     /// Returns mapping as a byte slice
     /// # Safety
     /// This function is unsafe because it is impossible to ensure the range of bytes is immutable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ impl Drop for ShmemConf {
 }
 #[allow(clippy::new_without_default)]
 impl ShmemConf {
+    // TODO Make droppable false by default and create a new method to set it, rather than creating a breaking change to the API 
     /// Create a new default shmem config
     pub fn new(droppable: bool) -> Self {
         if !droppable {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ impl Drop for ShmemConf {
 }
 #[allow(clippy::new_without_default)]
 impl ShmemConf {
-    // TODO Make droppable false by default and create a new method to set it, rather than creating a breaking change to the API 
+    // TODO Make droppable true by default and create a new method to set it, rather than creating a breaking change to the API 
     /// Create a new default shmem config
     pub fn new(droppable: bool) -> Self {
         if !droppable {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -84,7 +84,11 @@ pub fn check_available_space(map_size: usize) -> Result<(), ShmemError> {
 }
 
 /// Creates a mapping specified by the uid and size
-pub fn create_mapping(unique_id: &str, map_size: usize, droppable: bool) -> Result<MapData, ShmemError> {
+pub fn create_mapping(
+    unique_id: &str,
+    map_size: usize,
+    droppable: bool,
+) -> Result<MapData, ShmemError> {
     //Create shared memory file descriptor
     debug!("Creating persistent mapping at {}", unique_id);
     let shmem_fd = match shm_open(
@@ -186,7 +190,7 @@ pub fn open_mapping(unique_id: &str, droppable: bool) -> Result<MapData, ShmemEr
     //Get mmap size
     new_map.map_size = match fstat(new_map.map_fd) {
         Ok(v) => v.st_size as usize,
-        Err(e) => return Err(ShmemError::MapOpenFailed(e as u32)), 
+        Err(e) => return Err(ShmemError::MapOpenFailed(e as u32)),
     };
 
     //Map memory into our address space
@@ -194,11 +198,11 @@ pub fn open_mapping(unique_id: &str, droppable: bool) -> Result<MapData, ShmemEr
     new_map.map_ptr = match unsafe {
         mmap(
             null_mut(),                                   //Desired addr
-            new_map.map_size,                           //size of mapping
+            new_map.map_size,                             //size of mapping
             ProtFlags::PROT_READ | ProtFlags::PROT_WRITE, //Permissions on pages
-            MapFlags::MAP_SHARED,                        //What kind of mapping
-            new_map.map_fd,                                    //fd
-            0,                                          //Offset into fd
+            MapFlags::MAP_SHARED,                         //What kind of mapping
+            new_map.map_fd,                               //fd
+            0,                                            //Offset into fd
         )
     } {
         Ok(v) => {
@@ -240,7 +244,7 @@ pub fn resize_segment(map_data: &mut MapData, new_size: usize) -> Result<(), Shm
     //Enlarge the memory descriptor file size to the requested map size
     match ftruncate(map_data.map_fd, new_size as _) {
         Ok(_) => {}
-        Err(e) => return Err(ShmemError::UnknownOsError(e as u32))
+        Err(e) => return Err(ShmemError::UnknownOsError(e as u32)),
     };
 
     Ok(())
@@ -267,11 +271,11 @@ pub fn reload_mapping(map_data: &mut MapData) -> Result<(), ShmemError> {
     // Remap into our address space
     map_data.map_ptr = match unsafe {
         mmap(
-            desired_address,                                //Desired addr
+            desired_address,                              //Desired addr
             map_data.map_size,                            //size of mapping
-            ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,   //Permissions on pages
-            MapFlags::MAP_SHARED,                          //What kind of mapping
-            map_data.map_fd,                                     //file descriptor
+            ProtFlags::PROT_READ | ProtFlags::PROT_WRITE, //Permissions on pages
+            MapFlags::MAP_SHARED,                         //What kind of mapping
+            map_data.map_fd,                              //file descriptor
             0,                                            //Offset inside "file"
         )
     } {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,4 +1,4 @@
-use ::winapi::{
+use winapi::{
     shared::{ntdef::NULL, winerror::ERROR_ALREADY_EXISTS},
     um::{
         errhandlingapi::GetLastError,


### PR DESCRIPTION
- Introduces a number of utility functions around resizing and reloading memory maps. 
- Adds droppable flag to the shmem config which accounts for cases where using the logic through an FFI might lead to the memory mapped region being dropped even while it still needs to be valid (as Rust's drop logic doesn't have knowledge of the flow on the other side of the FFI).
- Moves the in-memory representation of the pointer to the address from mut* u8 to a usize to allow safety for sending and syncing between threads.

Testing:
- The few tests within the project pass
- This library has been used as a local dependency for another project where the unit test suite, and integration test suite have passed.
