### PR TITLE
Rely on `ftruncate` to return `Errno::ENOMEM` instead of using sysinfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ logging = ["log"]
 [dependencies]
 cfg-if = "1.0"
 rand = "0.8"
-sysinfo = "0.20.3"
 log = { version = "0.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/examples/event.rs
+++ b/examples/event.rs
@@ -6,7 +6,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     // Attempt to create a mapping or open if it already exists
     info!("Getting the shared memory mapping");
-    let shmem = match ShmemConf::new(true).size(4096).flink("event_mapping").create() {
+    let shmem = match ShmemConf::new(true)
+        .size(4096)
+        .flink("event_mapping")
+        .create()
+    {
         Ok(m) => m,
         Err(ShmemError::LinkExists) => ShmemConf::new(true).flink("event_mapping").open()?,
         Err(e) => return Err(Box::new(e)),

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,7 +33,7 @@ impl std::fmt::Display for ShmemError {
             ShmemError::MappingIdExists => f.write_str("Shared memory OS specific ID already exists"),
             ShmemError::MapCreateFailed(err) => write!(f, "Creating the shared memory failed, os error {}", err),
             ShmemError::MapOpenFailed(err) => write!(f, "Opening the shared memory failed, os error {}", err),
-            ShmemError::UnmapFailed(err) => write!(f, "Unmapping the shared memory failed, os (nix) error {}", err.to_string()),
+            ShmemError::UnmapFailed(err) => write!(f, "Unmapping the shared memory failed, os (nix) error {}", err),
             ShmemError::UnknownOsError(err) => write!(f, "An unexpected OS error occurred, os error {}", err),
             ShmemError::DevShmOutOfMemory => write!(f, "`/dev/shm`is out of memory"),
             ShmemError::CannotReadDevShm => write!(f, "Cannot get stats for `/dev/shm`"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,7 @@ pub enum ShmemError {
     MappingIdExists,
     MapCreateFailed(u32),
     MapOpenFailed(u32),
+    #[cfg(unix)]
     UnmapFailed(nix::Error),
     UnknownOsError(u32),
     DevShmOutOfMemory,
@@ -33,6 +34,7 @@ impl std::fmt::Display for ShmemError {
             ShmemError::MappingIdExists => f.write_str("Shared memory OS specific ID already exists"),
             ShmemError::MapCreateFailed(err) => write!(f, "Creating the shared memory failed, os error {}", err),
             ShmemError::MapOpenFailed(err) => write!(f, "Opening the shared memory failed, os error {}", err),
+            #[cfg(unix)]
             ShmemError::UnmapFailed(err) => write!(f, "Unmapping the shared memory failed, os (nix) error {}", err),
             ShmemError::UnknownOsError(err) => write!(f, "An unexpected OS error occurred, os error {}", err),
             ShmemError::DevShmOutOfMemory => write!(f, "`/dev/shm`is out of memory"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,9 +214,9 @@ impl ShmemConf {
             };
 
             #[cfg(unix)]
-                let mapping = os_impl::open_mapping(unique_id, self.droppable);
+            let mapping = os_impl::open_mapping(unique_id, self.droppable);
             #[cfg(windows)]
-                let mapping = os_impl::open_mapping(unique_id, self.size);
+            let mapping = os_impl::open_mapping(unique_id, self.size);
             match mapping {
                 Ok(m) => {
                     self.size = m.map_size;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ impl Drop for ShmemConf {
 }
 #[allow(clippy::new_without_default)]
 impl ShmemConf {
-    // TODO Make droppable true by default and create a new method to set it, rather than creating a breaking change to the API 
+    // TODO Make droppable true by default and create a new method to set it, rather than creating a breaking change to the API
     /// Create a new default shmem config
     pub fn new(droppable: bool) -> Self {
         if !droppable {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -27,6 +27,9 @@ pub struct MapData {
     pub map_ptr: *mut u8,
 }
 
+unsafe impl Send for MapData {}
+unsafe impl Sync for MapData {}
+
 /// Shared memory teardown for linux
 impl Drop for MapData {
     ///Takes care of properly closing the `SharedMem` (`munmap()`, `shmem_unlink()`, `close()`)

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -7,9 +7,9 @@ use ::nix::unistd::{close, ftruncate};
 use crate::log::*;
 use crate::ShmemError;
 
+use nix::errno::Errno;
 use std::os::unix::io::RawFd;
 use std::ptr::null_mut;
-use nix::errno::Errno;
 
 pub struct MapData {
     droppable: bool,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -143,7 +143,11 @@ fn get_tmp_dir() -> Result<PathBuf, ShmemError> {
 }
 
 //Creates a mapping specified by the uid and size
-pub fn create_mapping(unique_id: &str, map_size: usize, _droppable: bool) -> Result<MapData, ShmemError> {
+pub fn create_mapping(
+    unique_id: &str,
+    map_size: usize,
+    _droppable: bool,
+) -> Result<MapData, ShmemError> {
     // Create file to back the shared memory
     let mut file_path = get_tmp_dir()?;
     file_path.push(unique_id.trim_start_matches('/'));

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -143,7 +143,7 @@ fn get_tmp_dir() -> Result<PathBuf, ShmemError> {
 }
 
 //Creates a mapping specified by the uid and size
-pub fn create_mapping(unique_id: &str, map_size: usize) -> Result<MapData, ShmemError> {
+pub fn create_mapping(unique_id: &str, map_size: usize, _droppable: bool) -> Result<MapData, ShmemError> {
     // Create file to back the shared memory
     let mut file_path = get_tmp_dir()?;
     file_path.push(unique_id.trim_start_matches('/'));

--- a/tests/posix_semantics.rs
+++ b/tests/posix_semantics.rs
@@ -26,7 +26,11 @@ fn posix_behavior() {
                 let shmem = ShmemConf::new(true).size(4096).create().unwrap();
                 let os_id = String::from(shmem.get_os_id());
                 // Creating two `Shmem`s with the same `os_id` should fail
-                assert!(ShmemConf::new(true).size(4096).os_id(&os_id).create().is_err());
+                assert!(ShmemConf::new(true)
+                    .size(4096)
+                    .os_id(&os_id)
+                    .create()
+                    .is_err());
                 tx_b.send(os_id.clone()).unwrap();
                 tx_c.send(os_id.clone()).unwrap();
                 // Wait for threads B and C to confirm they have created their instances.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We experience `DevShmOutOfMemory` errors even if enough memory is available. This most probably is either because `sysinfo` has an invalid output or the used threshold is too low. In either way, this can be fixed by relying on the error of `ftruncate` instead of calculating the size ourselves.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1199548034582004/1201566010883987/f) _(internal)_

## 🔍 What does this change?

- Remove call to `check_available_space` (and remove this function as it's unused)
- Detect `Errno::ENOMEM` and emit `DevShmOutOfMemory` in this case
- Remove dependency on `sysinfo` (unused)

## ❓ How to test this?

The bug is hard to reproduce and is only possible on Unix (not macOS, as `ftruncate` is not working properly there). This is how I verified that this is working:
- Run the test and hope for `DevShmOutOfMemory`
- Apply the changes and watch the error disappearing

